### PR TITLE
Fix #14 - negate world.isClient in BumbleLlamaEntity

### DIFF
--- a/src/main/java/io/github/llamarama/team/common/entity/bumbllama/BumbleLlamaEntity.java
+++ b/src/main/java/io/github/llamarama/team/common/entity/bumbllama/BumbleLlamaEntity.java
@@ -93,7 +93,7 @@ public class BumbleLlamaEntity extends WoollyLlamaEntity {
         BlockState stateForBoneMeal = this.world.getBlockState(down);
 
         boolean isChosen = this.random.nextInt(384) == 0;
-        if (isChosen && world.isClient) {
+        if (isChosen && !world.isClient) {
             this.tryGrowPlant(down, stateForBoneMeal);
         }
     }


### PR DESCRIPTION
As per @0xJoeMama|s suggestion I switched the boolean check in `io.github.llamarama.team.common.entity.bumbllama.BumbleLlamaEntity#tick` and verified the logic for this change myself too.

This pr is not tested, but I am certain it will resolve the issue.